### PR TITLE
fix: Reset doesn't bring the screen to the starting pos

### DIFF
--- a/src/display_manager.cpp
+++ b/src/display_manager.cpp
@@ -97,8 +97,8 @@ void DisplayManager::processEvents()
 			else if ((event.key.code == sf::Keyboard::D)) debug_mode = !debug_mode;
 			else if ((event.key.code == sf::Keyboard::R))
 			{
-				m_offsetX = 0.0f;
-				m_offsetY = 0.0f;
+				m_offsetX = m_windowOffsetX;
+				m_offsetY = m_windowOffsetY;
 				m_zoom = 1.0f;
 			}
 			else if ((event.key.code == sf::Keyboard::S))


### PR DESCRIPTION
Reset set the offset to 0 instead of the default windowOffset,
so the top left corner was at the center of the screen.

It used to be like this, after pressing R:

![image](https://user-images.githubusercontent.com/7505454/113523531-3d466500-95a8-11eb-9c1b-80a12d9ebb7b.png)
