### PR TITLE
Fix compiler warnings

### DIFF
--- a/include/ant.hpp
+++ b/include/ant.hpp
@@ -49,7 +49,6 @@ struct Ant
 	void updatePosition(World& world, float dt)
 	{
 		sf::Vector2f v = direction.getVec();
-		const sf::Vector2f next_position = position + (dt * move_speed) * v;
 		const HitPoint intersection = world.markers.getFirstHit(position, v, dt * move_speed);
 		if (intersection.cell) {
 			++hits;

--- a/include/ant.hpp
+++ b/include/ant.hpp
@@ -15,10 +15,6 @@ struct Ant
 	Ant(float x, float y, float angle)
 		: position(x, y)
 		, direction(angle)
-		, last_direction_update(RNGf::getUnder(1.0f) * direction_update_period)
-		, last_marker(RNGf::getUnder(1.0f) * marker_period)
-		, phase(Mode::ToFood)
-		, liberty_coef(RNGf::getRange(0.0001f, 0.001f))
 		, hits(0)
 		, markers_count(0.0f)
 	{
@@ -179,13 +175,13 @@ struct Ant
 	const float direction_noise_range = PI * 0.1f;
 	const float colony_size = 20.0f;
 
-	Mode phase;
+	Mode phase{Mode::ToFood};
 	sf::Vector2f position;
 	Direction direction;
 	uint32_t hits;
 
-	float last_direction_update;
+	float last_direction_update = RNGf::getUnder(1.0f) * direction_update_period;
 	float markers_count;
-	float last_marker;
-	float liberty_coef;
+	float last_marker = RNGf::getUnder(1.0f) * marker_period;
+	float liberty_coef = RNGf::getRange(0.0001f, 0.001f);
 };

--- a/include/ant.hpp
+++ b/include/ant.hpp
@@ -12,8 +12,6 @@
 
 struct Ant
 {
-	Ant() = default;
-
 	Ant(float x, float y, float angle)
 		: position(x, y)
 		, direction(angle)

--- a/include/ant.hpp
+++ b/include/ant.hpp
@@ -29,7 +29,7 @@ struct Ant
 
 		last_direction_update += dt;
 		if (last_direction_update > direction_update_period) {
-			findMarker(world, dt);
+			findMarker(world);
 			direction += RNGf::getFullRange(direction_noise_range);
 			last_direction_update = 0.0f;
 		}
@@ -88,7 +88,7 @@ struct Ant
 		}
 	}
 
-	void findMarker(World& world, float dt)
+	void findMarker(World& world)
 	{
 		// Init
 		const float sample_angle_range = PI * 0.8f;

--- a/include/colony.hpp
+++ b/include/colony.hpp
@@ -11,7 +11,6 @@ struct Colony
 {
 	Colony(float x, float y, uint32_t n)
 		: position(x, y)
-		, last_direction_update(0.0f)
 		, ants_va(sf::Quads, 4 * n)
 	{
 		for (uint32_t i(n); i--;) {
@@ -64,7 +63,7 @@ struct Colony
 	mutable sf::VertexArray ants_va;
 	const float size = 20.0f;
 
-	float last_direction_update;
+	float last_direction_update = 0.0f;
 	const float direction_update_period = 0.25f;
 
 };

--- a/include/direction.hpp
+++ b/include/direction.hpp
@@ -6,10 +6,9 @@
 struct Direction
 {
 public:
-	Direction(float angle, float rotation_speed = 10.0f)
+	Direction(float angle)
 		: m_angle(angle)
 		, m_target_angle(angle)
-		, m_rotation_speed(rotation_speed)
 	{
 		updateVec();
 		m_target_vec = m_vec;
@@ -69,7 +68,6 @@ private:
 	sf::Vector2f m_target_vec;
 	float m_angle;
 	float m_target_angle;
-	float m_rotation_speed;
 
 	void updateVec()
 	{

--- a/include/display_manager.hpp
+++ b/include/display_manager.hpp
@@ -34,15 +34,15 @@ public:
 	sf::Vector2f worldCoordToDisplayCoord(const sf::Vector2f&);
 	sf::Vector2f displayCoordToWorldCoord(const sf::Vector2f&);
 
-	bool clic;
-	bool pause;
-	bool update;
+	bool clic = false;
+	bool pause = false;
+	bool update = true;
 	float render_time;
-	bool speed_mode;
-	bool debug_mode;
-	bool wall_mode;
-	bool render_ants;
-	bool remove_wall;
+	bool speed_mode = false;
+	bool debug_mode = false;
+	bool wall_mode = false;
+	bool render_ants = true;
+	bool remove_wall = false;
 
 	sf::Vector2f getClicPosition() const
 	{
@@ -52,13 +52,16 @@ public:
 private:
 	sf::RenderTarget& m_target;
 	sf::RenderWindow& m_window;
-	sf::VertexArray m_va;
+	sf::VertexArray m_va{sf::Quads, 0};
 
 	World& m_world;
 	Colony& m_colony;
 
-	bool m_mouse_button_pressed;
+	bool m_mouse_button_pressed = false;
 	sf::Vector2i m_drag_clic_position, m_clic_position;
 
-    float m_zoom, m_offsetX, m_offsetY, m_windowOffsetX, m_windowOffsetY;
+    float m_zoom = 1.0f;
+	float m_windowOffsetX, m_windowOffsetY;
+	float m_offsetX = 0.0f;
+	float m_offsetY = 0.0f;
 };

--- a/include/grid.hpp
+++ b/include/grid.hpp
@@ -12,9 +12,9 @@ struct Grid
 	const int32_t width, height, cell_size;
 
 	Grid(int32_t width_, int32_t height_, uint32_t cell_size_)
-		: cell_size(cell_size_)
-		, width(width_ / cell_size_)
+		: width(width_ / cell_size_)
 		, height(height_ / cell_size_)
+		, cell_size(cell_size_)
 	{
 		cells.resize(width * height);
 	}

--- a/include/number_generator.hpp
+++ b/include/number_generator.hpp
@@ -112,7 +112,7 @@ public:
 	{}
 
 	// random_device is not copyable
-	IntegerNumberGenerator(const IntegerNumberGenerator<T>& right)
+	IntegerNumberGenerator(const IntegerNumberGenerator<T>&)
 		: NumberGenerator()
 	{}
 

--- a/include/world.hpp
+++ b/include/world.hpp
@@ -20,8 +20,8 @@ struct World
 	WorldRenderer renderer;
 
 	World(uint32_t width, uint32_t height)
-		: markers(width, height, 4)
-		, size(to<float>(width), to<float>(height))
+		: size(to<float>(width), to<float>(height))
+		, markers(width, height, 4)
 		, renderer(markers, va_markers)
 	{
 		for (int32_t x(0); x < markers.width; x++) {

--- a/include/world_renderer.hpp
+++ b/include/world_renderer.hpp
@@ -42,7 +42,6 @@ struct WorldRenderer : public AsyncRenderer
 		const sf::Vector3f to_food_color(Conf::TO_FOOD_COLOR.r / 255.0f, Conf::TO_FOOD_COLOR.g / 255.0f, Conf::TO_FOOD_COLOR.b / 255.0f);
 
 		uint64_t i = 0;
-		const float cell_size = to<float>(grid.cell_size);
 		for (int32_t x(0); x < grid.width; x++) {
 			for (int32_t y(0); y < grid.height; y++) {
 				const auto& cell = grid.getCst(sf::Vector2i(x, y));

--- a/src/display_manager.cpp
+++ b/src/display_manager.cpp
@@ -2,23 +2,10 @@
 
 
 DisplayManager::DisplayManager(sf::RenderTarget& target, sf::RenderWindow& window, World& world, Colony& colony)
-	: m_window(window)
-	, m_target(target)
-	, m_zoom(1.0f)
-	, m_offsetX(0.0f)
-	, m_offsetY(0.0f)
-	, speed_mode(false)
-	, m_va(sf::Quads, 0)
-	, update(true)
-	, debug_mode(false)
+	: m_target(target)
+	, m_window(window)
 	, m_world(world)
 	, m_colony(colony)
-	, clic(false)
-	, m_mouse_button_pressed(false)
-	, pause(false)
-	, wall_mode(false)
-	, render_ants(true)
-	, remove_wall(false)
 {
 	m_windowOffsetX = m_window.getSize().x * 0.5f;
     m_windowOffsetY = m_window.getSize().y * 0.5f;

--- a/src/display_manager.cpp
+++ b/src/display_manager.cpp
@@ -97,31 +97,31 @@ void DisplayManager::processEvents()
 			break;
 		case sf::Event::KeyPressed:
 			if (event.key.code == sf::Keyboard::Escape) m_window.close();
-			else if ((event.key.code == sf::Keyboard::Subtract)) zoom(0.8f);
-			else if ((event.key.code == sf::Keyboard::Add)) zoom(1.2f);
-			else if ((event.key.code == sf::Keyboard::Space)) update = !update;
-			else if ((event.key.code == sf::Keyboard::P)) pause = !pause;
-			else if ((event.key.code == sf::Keyboard::E)) {
+			else if (event.key.code == sf::Keyboard::Subtract) zoom(0.8f);
+			else if (event.key.code == sf::Keyboard::Add) zoom(1.2f);
+			else if (event.key.code == sf::Keyboard::Space) update = !update;
+			else if (event.key.code == sf::Keyboard::P) pause = !pause;
+			else if (event.key.code == sf::Keyboard::E) {
 				remove_wall = !remove_wall;
 				if (remove_wall) {
 					wall_mode = false;
 				}
 			}
-			else if ((event.key.code == sf::Keyboard::A)) render_ants = !render_ants;
-			else if ((event.key.code == sf::Keyboard::M)) m_world.renderer.draw_markers = !m_world.renderer.draw_markers;
-			else if ((event.key.code == sf::Keyboard::W)) {
+			else if (event.key.code== sf::Keyboard::A) render_ants = !render_ants;
+			else if (event.key.code == sf::Keyboard::M) m_world.renderer.draw_markers = !m_world.renderer.draw_markers;
+			else if (event.key.code == sf::Keyboard::W) {
 				wall_mode = !wall_mode;
 				if (wall_mode) {
 					remove_wall = false;
 				}
 			}
-			else if ((event.key.code == sf::Keyboard::R))
+			else if (event.key.code == sf::Keyboard::R)
 			{
 				m_offsetX = m_windowOffsetX;
 				m_offsetY = m_windowOffsetY;
 				m_zoom = 1.0f;
 			}
-			else if ((event.key.code == sf::Keyboard::S))
+			else if (event.key.code == sf::Keyboard::S)
 			{
 				speed_mode = !speed_mode;
 				m_window.setFramerateLimit(speed_mode ? 0 : 60);


### PR DESCRIPTION
Temporarily enabled some extra compiler warnings (`-Wall` and `-Wextra` mostly) and fixed everything it found. I used GCC 10, GCC 11, and AppleClang 12 to test this. If you like these changes, we could enable `-Werror` if you wanted to ensure no more warnings find their way in.

Hope this helps, @johnBuffer.