### PR TITLE
Building a static library using docker under ubuntu 18.04.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(WIN32)
    set(WIN32_GUI WIN32)
 endif()
 
-set(SFML_LIBS sfml-graphics sfml-system sfml-window )
+set(SFML_LIBS sfml-graphics sfml-system sfml-window)
 
 file(GLOB SOURCES src/*.cpp)
 add_executable(${PROJECT_NAME} ${WIN32_GUI} ${SOURCES})

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Get image from Docker Hub
-FROM iorfanidi/ubuntu-20.04-gcc-cmake-git:latest
+FROM ubuntu:18.04
 
 # Specify the working directory
 WORKDIR /AntSimulator
@@ -10,8 +10,9 @@ COPY . /AntSimulator
 # Update apps on the base image
 RUN apt-get update && \
     apt-get install -y \
+    # Install GCC, CMake, Git
+    gcc cmake build-essential git \
     # Install additional libraries
-    libsfml-dev \
     libfreetype6-dev \
     libjpeg-dev \
     xorg-dev \
@@ -27,9 +28,19 @@ RUN apt-get update && \
     libopenal-dev \
     libpthread-stubs0-dev \
     libudev-dev \
-    && \
-    # AntSimulator Build
-    cd ../../.. && cd AntSimulator/ && \
+    libxcursor-dev \
+    libxinerama-dev \
+    libxi-dev &&  \
+    # SFML static build
+    git clone https://github.com/SFML/SFML.git && \
+    cd SFML && \
     rm -rf build && mkdir build && cd build && \
-    cmake cmake -DCMAKE_PREFIX_PATH=/usr/local/cmake/SFML/ -DCMAKE_BUILD_TYPE=Release .. && \
+    cmake -G "Unix Makefiles" -DBUILD_SHARED_LIBS=FALSE -DCMAKE_BUILD_TYPE=Release .. && \
+    cmake --build . && \
+    make install && \
+    cd ../../.. && \
+    # AntSimulator build
+    cd AntSimulator/ && \
+    rm -rf build && mkdir build && cd build && \
+    cmake -DCMAKE_PREFIX_PATH=/usr/local/cmake/SFML/ -DSFML_STATIC_LIBRARIES=TRUE -DCMAKE_BUILD_TYPE=Release .. && \
     cmake --build .

--- a/install_from_docker.sh
+++ b/install_from_docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-docker build -t myimages/ant-simulator:latest .
-docker create -it --name dummy myimages/ant-simulator:latest bash
+docker build -t ant-simulator:latest .
+docker create -it --name dummy ant-simulator:latest bash
 docker cp dummy:/AntSimulator/build/AntSimulator .
 rm -rf build/
 mkdir build/


### PR DESCRIPTION
Hi bro!
Fixed a problem with running under ubuntu 18.04.
Since there is no necessary version of the SFML library in the ubuntu 18.04 repositories, we have to build it with a static version of SFML from the project sources. The static version of the SFML library is also missing from the ubuntu 18.04 repository(and even 20.04).

Static SFML build:
The flag "BUILD_SHARED_LIBS=FALSE" indicates that it is necessary to build a static version of the SFML library.

Building an Ant Simulator with a static version:
The "SFML_STATIC_LIBRARIES=TRUE" flag indicates that the SFML library should be statically linked.

Now AntSimulator is tested on ubuntu 20.04 and 18.04.