### PR TITLE
Fixed shebang

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-set -e
+#!/bin/sh -e
 
 mkdir -p build && cd build
 cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..

--- a/install_from_docker.sh
+++ b/install_from_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 docker build -t ant-simulator:latest .
 docker create -it --name dummy ant-simulator:latest bash


### PR DESCRIPTION
The location of the bash utility is not guaranteed to be in '/usr/bin',
therefore '#!/usr/bin/env bash' would be more suitable.
But we actually don't need any bash-isms, therefore '#!/bin/sh' should be used,
since not every POSIX system has bash pre-installed (e.g. OpenWrt).

Signed-off-by: Benjamin Stürz <benni@stuerz.xyz>