### PR TITLE
Fixed include paths for items in GUI/ for Mac

### DIFF
--- a/include/editor/GUI/button.hpp
+++ b/include/editor/GUI/button.hpp
@@ -1,8 +1,8 @@
 
 #pragma once
-#include "GUI/item.hpp"
+#include "item.hpp"
 #include "rounded_rectangle.hpp"
-#include "transition.hpp"
+#include "../transition.hpp"
 #include "text_label.hpp"
 
 

--- a/include/editor/GUI/container.hpp
+++ b/include/editor/GUI/container.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "GUI/item.hpp"
+#include "item.hpp"
 #include "common/color_utils.hpp"
 
 

--- a/include/editor/GUI/grid_container.hpp
+++ b/include/editor/GUI/grid_container.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "GUI/item.hpp"
+#include "item.hpp"
 
 
 namespace GUI

--- a/include/editor/GUI/scene.hpp
+++ b/include/editor/GUI/scene.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "GUI/item.hpp"
+#include "item.hpp"
 #include "utils.hpp"
 #include <common/event_manager.hpp>
 #include <vector>

--- a/include/editor/GUI/text_label.hpp
+++ b/include/editor/GUI/text_label.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "GUI/item.hpp"
+#include "item.hpp"
 
 
 namespace GUI


### PR DESCRIPTION
When I ran the `install.sh` script it would give me error such as:

```
-- Found SFML 2.5.1 in /opt/homebrew/lib/cmake/SFML
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/<username>/<path to repo>/AntSimulator/build
[ 50%] Building CXX object CMakeFiles/AntSimulator.dir/src/main.cpp.o
In file included from /Users/<username>/<path to repo>/AntSimulator/src/main.cpp:7:
In file included from /Users/<username>/<path to repo>/AntSimulator/include/editor/editor_scene.hpp:5:
In file included from /Users/<username>/<path to repo>/AntSimulator/include/editor/color_saver.hpp:3:
/Users/<username>/<path to repo>/AntSimulator/include/editor/GUI/grid_container.hpp:2:10: fatal error: 'GUI/item.hpp' file not found
#include "GUI/item.hpp"
         ^~~~~~~~~~~~~~
1 error generated.
make[2]: *** [CMakeFiles/AntSimulator.dir/src/main.cpp.o] Error 1
make[1]: *** [CMakeFiles/AntSimulator.dir/all] Error 2
make: *** [all] Error 2
```

So all I did is change the `GUI/` part of it and re-run the script. Did this for all the subsequent errors like this that showed up and after the 5th it compiled successfully.

I'm no C++ expert so this changes are kind of a botch, hope it helps someone having the same issue.