### PR TITLE
Add missing includes to header files

### DIFF
--- a/include/common/color_utils.hpp
+++ b/include/common/color_utils.hpp
@@ -1,7 +1,10 @@
 #pragma once
-#include <SFML/Graphics.hpp>
+
 #include "common/math.hpp"
 #include "common/number_generator.hpp"
+#include "common/utils.hpp"
+
+#include <SFML/Graphics.hpp>
 
 
 struct ColorUtils

--- a/include/common/double_buffer.hpp
+++ b/include/common/double_buffer.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+
+
 template<typename T>
 struct DoubleObject
 {

--- a/include/common/grid.hpp
+++ b/include/common/grid.hpp
@@ -1,7 +1,12 @@
 #pragma once
-#include <vector>
-#include <list>
+
+#include "common/utils.hpp"
+
 #include <SFML/System.hpp>
+
+#include <cstdint>
+#include <list>
+#include <vector>
 
 
 template<typename T>

--- a/include/common/index_vector.hpp
+++ b/include/common/index_vector.hpp
@@ -1,4 +1,6 @@
 #pragma once
+
+#include <cstdint>
 #include <vector>
 
 

--- a/include/common/math.hpp
+++ b/include/common/math.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cmath>
+
+
 struct Math
 {
     static constexpr float PI = 3.141592653f;

--- a/include/common/utils.hpp
+++ b/include/common/utils.hpp
@@ -1,6 +1,9 @@
 #pragma once
+
 #include <SFML/Graphics.hpp>
+
 #include <cmath>
+#include <memory>
 #include <sstream>
 
 

--- a/include/editor/GUI/container.hpp
+++ b/include/editor/GUI/container.hpp
@@ -1,6 +1,9 @@
 #pragma once
-#include "editor/GUI/item.hpp"
+
 #include "common/color_utils.hpp"
+
+#include "editor/GUI/item.hpp"
+#include "editor/GUI/utils.hpp"
 
 
 namespace GUI

--- a/include/editor/GUI/empty_item.hpp
+++ b/include/editor/GUI/empty_item.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "item.hpp"
+
 
 namespace GUI
 {

--- a/include/editor/GUI/item.cpp
+++ b/include/editor/GUI/item.cpp
@@ -1,3 +1,0 @@
-#include "item.hpp"
-
-float GUI::Item::SCALE = 1.0f;

--- a/include/editor/GUI/item.hpp
+++ b/include/editor/GUI/item.hpp
@@ -1,7 +1,10 @@
 #pragma once
+
+#include "common/utils.hpp"
+#include "common/event_manager.hpp"
+#include "simulation/config.hpp"
+
 #include <SFML/Graphics.hpp>
-#include <common/event_manager.hpp>
-#include "utils.hpp"
 
 
 namespace GUI

--- a/include/editor/GUI/utils.hpp
+++ b/include/editor/GUI/utils.hpp
@@ -1,6 +1,10 @@
 #pragma once
-#include <common/utils.hpp>
+
+#include "common/utils.hpp"
+
 #include <SFML/Graphics.hpp>
+
+#include <functional>
 
 
 template<typename T>

--- a/include/editor/colony_creator/colony_stats.hpp
+++ b/include/editor/colony_creator/colony_stats.hpp
@@ -1,6 +1,12 @@
 #pragma once
+
 #include "editor/GUI/named_container.hpp"
+#include "editor/control_state.hpp"
+
+#include "common/index_vector.hpp"
 #include "common/graph.hpp"
+
+#include "simulation/colony/colony.hpp"
 
 
 struct ColonyChart : public GUI::Item

--- a/include/editor/colony_creator/colony_tool.hpp
+++ b/include/editor/colony_creator/colony_tool.hpp
@@ -1,11 +1,16 @@
 #pragma once
+
+#include "colony_stats.hpp"
+
 #include "editor/GUI/container.hpp"
 #include "editor/GUI/button.hpp"
 #include "editor/GUI/rounded_rectangle.hpp"
+#include "editor/GUI/toggle.hpp"
 #include "editor/color_picker/color_picker.hpp"
 #include "editor/control_state.hpp"
+
 #include "common/color_utils.hpp"
-#include "colony_stats.hpp"
+
 
 
 struct ColonyTool : GUI::Container

--- a/include/editor/color_saver.hpp
+++ b/include/editor/color_saver.hpp
@@ -1,7 +1,10 @@
 #pragma once
-#include "GUI/item.hpp"
-#include "GUI/grid_container.hpp"
+
 #include "GUI/button.hpp"
+#include "GUI/container.hpp"
+#include "GUI/grid_container.hpp"
+#include "GUI/item.hpp"
+
 #include "transition.hpp"
 
 

--- a/include/editor/control_state.hpp
+++ b/include/editor/control_state.hpp
@@ -1,7 +1,12 @@
 #pragma once
-#include <functional>
-#include <SFML/Graphics.hpp>
+
+#include "common/viewport_handler.hpp"
 #include "editor/transition.hpp"
+#include "simulation/simulation.hpp"
+
+#include <SFML/Graphics.hpp>
+
+#include <functional>
 
 
 struct ControlState

--- a/include/editor/slider.hpp
+++ b/include/editor/slider.hpp
@@ -1,4 +1,9 @@
+#pragma once
+
+#include "GUI/container.hpp"
 #include "GUI/item.hpp"
+#include "GUI/rounded_rectangle.hpp"
+#include "GUI/text_label.hpp"
 
 
 namespace edtr

--- a/include/editor/tool_selector.hpp
+++ b/include/editor/tool_selector.hpp
@@ -1,8 +1,12 @@
 #pragma once
-#include "GUI/container.hpp"
+
 #include "GUI/button.hpp"
+#include "GUI/container.hpp"
+#include "GUI/named_container.hpp"
+
 #include "control_state.hpp"
 #include "simulation/simulation.hpp"
+
 #include <future>
 
 

--- a/include/simulation/config.hpp
+++ b/include/simulation/config.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include <memory>
 #include <SFML/Graphics.hpp>
+
+#include <memory>
+#include <fstream>
 
 
 template<typename T>


### PR DESCRIPTION
Ensure that each header file can be compiled separately.
This is a prerequisite for moving code to cpp files for improved (re-)compilation times.